### PR TITLE
chore: readability - invert macro conditional

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,9 +7,7 @@
 #define EXT_ROOT (XOVI_ROOT "extensions.d/")
 #define FILES_ROOT (XOVI_ROOT "exthome/")
 
-#ifndef DEBUGFUNC
-#define CONSTRUCTOR __attribute__((constructor))
-#else
+#ifdef DEBUGFUNC
 #define CONSTRUCTOR
 
 void _ext_init();
@@ -21,6 +19,8 @@ int testFunc() {
 int main(){
     _ext_init();
 }
+#else
+#define CONSTRUCTOR __attribute__((constructor))
 #endif
 
 char *findBaseName(const char *fileName) {
@@ -87,4 +87,3 @@ void CONSTRUCTOR _ext_init() {
         printf("Cannot find extensions dir! Bailing!\n");
     }
 }
-


### PR DESCRIPTION
I know this will make me sound dense, but the `ifndef` vs `ifdef` made me totally misread this code.

it is the only ifndef in code you wrote. So while other (third-party) code in this repo uses ifndef, I'd expect most people to not need to understand the low-level hashing library.

If we can help others to understand, which I hope this would do, then, I think it could help.

What I understand now I'm more familiar with XOVI, thanks to your guidance, is that:

- it's executed before the program, due to having a constructor attribute, and being `LD_PRELOAD` 'ed
- this means it will execute before `xochitl` on the rMpp device
- from there it iterates the folders, attempts to prepare and then load extensions, which should have a constructor of their own, which would also be executed prior to `xochitl` executing it's `main` function
- I believe this means that the functions would have been transformed to use trampolines prior to being called (for overrides) by xovi
- by the time an extension constructor is called, then all of it's overrides, imports and exports have also been actioned by xovi