### PR TITLE
Fix trampoline injection for Thumb-2 code with 32-bit instruction accross trampoline boundary

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -133,8 +133,6 @@ Right now, apart from the race condition mentioned in [Hooks](#hooks), xovi shou
 
 Since the ARM32 code is still quite new, and hasn't been tested as thoroughly as aarch64, it might be less stable.
 
-Due to the lack of viable testing devices, while part of the codebase, THUMB functions' hooking has **NOT** been tested! Please be careful with THUMB functions.
-
 As of right now, only methods which take **up to 4 arguments** can be hooked in ARM32. This is due to the calling convention of 32-bit ARM, according to which in order to transfer more than 4 arguments, they should be passed onto the stack. Xovi's current implementation uses the stack internally to process the trampoline code, therefore arguments 5 and above will become corrupted while executing the original code of any hooked method. This is a temporary issue, and at some point will be fixed.
 
 ## Happy hacking!

--- a/src/trampolines/aarch64/aarch64.h
+++ b/src/trampolines/aarch64/aarch64.h
@@ -1,5 +1,6 @@
 #pragma once
 #define ARCHDEP_UNTRAMPOLINE_LENGTH (9 * 4)
 #define ARCHDEP_TRAMPOLINE_LENGTH (5 * 4)
+#define ARCHDEP_SYMBOLDATA_FIELDS
 typedef unsigned int instr_t;
 typedef unsigned long long int ptrint_t;

--- a/src/trampolines/arm32/arm32.h
+++ b/src/trampolines/arm32/arm32.h
@@ -1,5 +1,8 @@
 #pragma once
-#define ARCHDEP_UNTRAMPOLINE_LENGTH (4 * 4)
+#define ARCHDEP_UNTRAMPOLINE_LENGTH (5 * 4)
 #define ARCHDEP_TRAMPOLINE_LENGTH (2 * 4)
+#define ARCHDEP_SYMBOLDATA_FIELDS int trampoline_2_offset;
 typedef unsigned int instr_t;
 typedef unsigned int ptrint_t;
+typedef short unsigned int thumb_instr_t;
+

--- a/src/trampolines/arm32/untrampoline.S
+++ b/src/trampolines/arm32/untrampoline.S
@@ -168,6 +168,8 @@ untrampolineStackShift:
     ldmfd sp!, {r0-r3, r4, r5}
     bx lr
 
+.equ trampoline2OffsetOffset, 28
+
 untrampolineStep2:
     # After we enter the function, we need to get rid of the original code
     # as soon as possible.
@@ -196,7 +198,7 @@ untrampolineStep2:
     # Now copy original code (f) into the current address
     ldr r1, [r12, #8]
     add r1, r1, #8
-    mov r2, #4
+    mov r2, #5
     .l2:
     ldr r3, [r1], #4
     str r3, [r0], #4
@@ -214,10 +216,15 @@ untrampolineStep2:
 
     ldmfd sp!, {r0, r12}
     msr cpsr, r0
+
+    # Load function address plus offset needed for mixed 16/32-bit thumb instructions
+    ldr r0, [r12, #trampoline2OffsetOffset]
+    ldr r12, [r12]
+    add r12, r12, r0
+
     ldmfd sp!, {r0-r3, r4, lr}
     
-    ldr r12, [r12]
-    # Done. Return to the function.
+    # Done. Return to the function (plus offset for already executed instructions)
     add r12, r12, #8
     bx r12
 

--- a/src/trampolines/trampolines.h
+++ b/src/trampolines/trampolines.h
@@ -1,6 +1,7 @@
 // ALL FUNCTIONS DEFINED IN THIS FILE ARE ARCHITECTURE-DEPENDENT!!
 #pragma once
 #include <pthread.h>
+#include "archdepend.h"
 
 struct SymbolData {
     void *address;
@@ -13,6 +14,7 @@ struct SymbolData {
     int size;
 
     int argsize;
+    ARCHDEP_SYMBOLDATA_FIELDS
 
     pthread_mutex_t mutex;
 };


### PR DESCRIPTION
On ARM32, there was an edge-case where a Thumb-2 instruction could be partially overwritten by trampoline2, resulting in an illegal or inadvertently modified instruction being executed. This PR adjusts the beginning of trampoline2 slightly if it detects a thumb instruction that would be partially overwritten. To this end, trampoline2 had to be extended slightly from 4 to 5 words.
With these changes, patching of Thumb functions should be as stable as ARM32 functions.