### PR TITLE
Support symlinks to extensions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -98,7 +98,7 @@ void CONSTRUCTOR _ext_init() {
     if((rootDirOfExtensions = opendir(EXT_ROOT)) != NULL){
         // Try to load every extension
         while((entry = readdir(rootDirOfExtensions)) != NULL) {
-            if(entry->d_type == DT_REG){
+            if(entry->d_type == DT_REG || entry->d_type == DT_LNK){
                 // LOG("Loading: %s\n", entry->d_name);
                 char *fullName = findFullName(entry->d_name);
                 loadExtensionPass1(fullName, findBaseName(entry->d_name));


### PR DESCRIPTION
If the symlink points to a file (what we want):
```
[W]: Pass 1: Begin loading extension qt-resource-rebuilder from file /home/root/xovi/extensions.d/qt-resource-rebuilder.so
[I]: Pass 1: Extension version 0.3.0
[I]: Pass 1: Metadata chain length is 11
[I]: Pass 1: Found link table at 0x73327828
[I]: Pass 1: Loaded extension qt-resource-rebuilder from file /home/root/xovi/extensions.d/qt-resource-rebuilder.so
```

If the symlink points to a directory:
```
[W]: Pass 1: Begin loading extension thisisafolder from file /home/root/xovi/extensions.d/thisisafolder.so
[I]: Pass 1: Failed to load extension:
/home/root/xovi/extensions.d/thisisafolder.so: cannot read file data: Is a directory
[I]: Pass 1: Skipping extension thisisafolder.
```

If the symlink's target doesn't exist:
```
[W]: Pass 1: Begin loading extension doesntexist from file /home/root/xovi/extensions.d/doesntexist.so
[I]: Pass 1: Failed to load extension:
/home/root/xovi/extensions.d/doesntexist.so: cannot open shared object file: No such file or directory
[I]: Pass 1: Skipping extension doesntexist.
```

In all three cases xovi doesn't crash.