### PR TITLE
fix: argSize was mis spelled causing the arm32 build to fail

### DIFF
--- a/src/trampolines/arm32/arm32.c
+++ b/src/trampolines/arm32/arm32.c
@@ -94,7 +94,7 @@ struct SymbolData *pivotSymbol(const char *symbol, void *newaddr, struct Overrid
     s->returningClosureAllocSpace = closures;
 
     // untrampolineStackShift supports only even values of argsize, therefore we need to round up odd numbers
-    s->argsize = (extra.argsize + 1) & (~1);
+    s->argsize = (extra.argSize + 1) & (~1);
     s->disableMutex = extra.disableMutex;
 
     if(!is_thumb_func) {


### PR DESCRIPTION
I was trying to build arm32 and I got an error that this was mistyped, replacing `argsize `with `argSize `fixed the issue for me